### PR TITLE
main: allow user to sort input by size

### DIFF
--- a/src/bleanser/core/common.py
+++ b/src/bleanser/core/common.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
-from typing import NamedTuple, Sequence, Set, List, Iterator, Tuple, Dict, Iterable, Optional, Union
+from typing import NamedTuple, Sequence, Union
 
 from .utils import assert_never
 from .ext.logging import LazyLogger

--- a/src/bleanser/core/main.py
+++ b/src/bleanser/core/main.py
@@ -122,7 +122,7 @@ def main(*, Normaliser) -> None:
     call_main()
 
 
-def _get_paths(*, path: str, from_: Optional[int], to: Optional[int], sort_by: str, glob: bool=False) -> List[Path]:
+def _get_paths(*, path: str, from_: Optional[int], to: Optional[int], sort_by: str = "name", glob: bool=False) -> List[Path]:
     if not glob:
         pp = Path(path)
         assert pp.is_dir(), pp

--- a/src/bleanser/core/main.py
+++ b/src/bleanser/core/main.py
@@ -6,7 +6,6 @@ from typing import Optional, List
 
 from .common import logger, Dry, Move, Remove, Mode
 from .processor import compute_instructions, apply_instructions
-from .utils import mime
 
 import click # type: ignore
 

--- a/src/bleanser/core/processor.py
+++ b/src/bleanser/core/processor.py
@@ -1,16 +1,14 @@
 # TODO later, migrate core to use it?
 import click  # type: ignore
-from contextlib import contextmanager, ExitStack, closing
+from contextlib import contextmanager, ExitStack
 import os
 from pathlib import Path
-from pprint import pprint
 import re
 import shutil
-from subprocess import DEVNULL, check_call
 import sys
 from tempfile import TemporaryDirectory, gettempdir, NamedTemporaryFile
 from time import time
-from typing import Dict, Any, Iterator, Sequence, Optional, Tuple, Optional, Union, Callable, ContextManager, Protocol, List, Set, ClassVar, Type, Iterable, NoReturn
+from typing import Dict, Iterator, Sequence, Optional, Tuple, Optional, Union, ContextManager, Protocol, List, Set, ClassVar, Type, Iterable, NoReturn, Any, Callable
 
 
 from .common import Group, logger, Config, parametrize

--- a/src/bleanser/core/sqlite.py
+++ b/src/bleanser/core/sqlite.py
@@ -7,11 +7,11 @@ from pathlib import Path
 import sqlite3
 from sqlite3 import Connection
 from subprocess import check_call
-from typing import Dict, Any, Iterator, Iterable, Sequence, Optional, Callable, ContextManager, List, Set, Tuple, ClassVar
+from typing import Dict, Any, Iterator, Sequence, ContextManager, Set, Tuple, ClassVar
 
 
-from .common import logger, parametrize, Config
-from .common import Keep, Prune, Group
+from .common import parametrize, Config
+from .common import Keep, Prune
 from .utils import mime
 from .processor import compute_groups, compute_instructions, BaseNormaliser
 


### PR DESCRIPTION
some of my files have dates as the name but since theyre on different computers sorting by date doesnt always work

this lets you sort the `_get_files` by size instead, leaving the default `name`

trying to write a module for my zsh history, I end up switching between them back and forth:

```
81039  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*'
81040  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by name --glob ~/data/zsh_history/'*'
81041  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by name --glob ~/data/zsh_history/'*'
81042  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by name --glob ~/data/zsh_history/'*'
81043  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*'
81044  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*'
81045  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*' --multiway
81046  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*' --multiway
81047  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*' --multiway
81048  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by name --glob ~/data/zsh_history/'*'
81049  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by name --glob ~/data/zsh_history/'*'
81050  python3 -m src.bleanser.modules.zsh prune --threads 4 --move ~/.cache/removed --sort-by size --glob ~/data/zsh_history/'*'
```

which removes a few files at a time

not sure if this is ideal, but it does work, and all duplicate backups have been removed for me; going forward it should find the recently backed up files much easier using `--sort-by size`
