### PR TITLE
 core: some refactoring and cleanup for bleanser interface

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -1,6 +1,6 @@
 An explanation of the `--multiway`/`--prune-dominated` options, modified from [zulip chat](https://memex.zulipchat.com/#narrow/stream/279601-hpi/topic/bleanser/near/258276779)
 
-Say you had a bunch of sqlite databases and mapped them onto text dumps using `do_cleanup`. The idea is to figure out which dumps are redundant.
+Say you had a bunch of sqlite databases and mapped them onto text dumps using `normalise`. The idea is to figure out which dumps are redundant.
 
 Say you've got dumps `C.sql` and `B.sql` -- and you diff them (like literally, [`diff`](https://man7.org/linux/man-pages/man1/diff.1.html))
 

--- a/src/bleanser/core/common.py
+++ b/src/bleanser/core/common.py
@@ -59,11 +59,6 @@ class Keep(Instruction):
     pass
 
 
-class Config(NamedTuple):
-    prune_dominated: bool = False
-    multiway       : bool = False
-
-
 ### helper to define paramertized tests in function's body
 from .utils import under_pytest
 if under_pytest:

--- a/src/bleanser/core/modules/extract.py
+++ b/src/bleanser/core/modules/extract.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Iterator, Any
 
 
-from bleanser.core.processor import BaseNormaliser, unique_file_in_tempdir, sort_file
+from bleanser.core.processor import BaseNormaliser, unique_file_in_tempdir, sort_file, Normalised
 
 
 class ExtractObjectsNormaliser(BaseNormaliser):
@@ -42,13 +42,11 @@ class ExtractObjectsNormaliser(BaseNormaliser):
                 f.write("\n")
 
     @contextmanager
-    def do_cleanup(self, path: Path, *, wdir: Path) -> Iterator[Path]:
-        with self.unpacked(path, wdir=wdir) as upath:
-            cleaned = unique_file_in_tempdir(input_filepath=path, wdir=wdir, suffix=path.suffix)
-            del path
+    def normalise(self, *, path: Path) -> Iterator[Normalised]:
+        cleaned = unique_file_in_tempdir(input_filepath=path, dir=self.tmp_dir, suffix=path.suffix)
 
-            self._emit_history(upath, cleaned)
-            sort_file(cleaned)
+        self._emit_history(path, cleaned)
+        sort_file(cleaned)
 
         yield cleaned
 

--- a/src/bleanser/core/modules/json.py
+++ b/src/bleanser/core/modules/json.py
@@ -24,8 +24,6 @@ class JsonNormaliser(BaseNormaliser):
 
     @contextmanager
     def do_cleanup(self, path: Path, *, wdir: Path) -> Iterator[Path]:
-        assert path.stat().st_size > 0, path  # just in case
-
         with self.unpacked(path=path, wdir=wdir) as upath:
             pass
         del path # just to prevent from using by accident

--- a/src/bleanser/tests/test_hypothesis.py
+++ b/src/bleanser/tests/test_hypothesis.py
@@ -11,11 +11,11 @@ data = TESTDATA / 'hypothesis'
 
 # total time about 5s?
 @pytest.mark.parametrize('num', range(10))
-def test_normalise_one(tmp_path: Path, num) -> None:
+def test_normalise_one(tmp_path: Path, num: int) -> None:
     from bleanser.tests.common import skip_if_no_data; skip_if_no_data()
     path = data / 'hypothesis_20210625T220028Z.json'
-    n = Normaliser()
-    with n.do_cleanup(path, wdir=tmp_path):
+    n = Normaliser(original=path, base_tmp_dir=tmp_path)
+    with n.do_normalise():
         pass
 
 


### PR DESCRIPTION
- rename do_cleanup to normalise (backwards compatible)
- no need to pass around wdir anymore, it should be available in self.tmp_dir attribute
- do_normalise now handles boilerplate like decompression so it's not necessarry to do manually in child clases
- more consistent temporary directory handling everywhere