### PR TITLE
core.modules.sqlite: get rid of libmagic dependency for mime detection, check header directly

### DIFF
--- a/.ci/run
+++ b/.ci/run
@@ -18,7 +18,6 @@ if [ -n "${CI-}" ]; then
     case "$OSTYPE" in
     darwin*)
         # macos
-        brew install libmagic # for python-magic
         brew install diffutils # for GNU diff
         ;;
     cygwin* | msys* | win*)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ Homepage = "https://github.com/karlicoss/bleanser"
 
 [project.optional-dependencies]
 extra = [
-    "python-magic",  # more reliable mimetype detection -- requires extra binaries, so perhaps best to keep optional
     "logzero"     ,  # nicer logging, but can work without it
 ]
 json = [

--- a/src/bleanser/core/modules/sqlite.py
+++ b/src/bleanser/core/modules/sqlite.py
@@ -19,7 +19,6 @@ from ..processor import (
     sort_file,
     unique_file_in_tempdir,
 )
-from ..utils import mime
 
 AllowedBlobs = frozenset[tuple[str, str]]
 
@@ -125,13 +124,10 @@ class SqliteNormaliser(BaseNormaliser):
     @contextmanager
     def normalise(self, *, path: Path) -> Iterator[Normalised]:
         # note: deliberately keeping mime check inside do_cleanup, since it's executed in a parallel process
-        # otherwise it essentially blocks waiting for all mimes to compute..
-        mp = mime(path)
-        assert mp in {
-            'application/x-sqlite3',
-            'application/vnd.sqlite3',
-        }, mp
-        ##
+        # ok, this is much easier than detecting mime or whatever...
+        with path.open('rb') as fb:
+            header = fb.read(16)
+            assert header == b"SQLite format 3\x00", header
 
         # TODO handle compressed databases later... need to think how to work around checking for no wal etc..
         upath = path

--- a/src/bleanser/core/utils.py
+++ b/src/bleanser/core/utils.py
@@ -45,48 +45,10 @@ def timing(f):
     return wrapped
 
 
-# make it lazy, otherwise it might crash on module import (e.g. on Windows)
-# ideally would be nice to fix it properly https://github.com/ahupp/python-magic#windows
-import warnings
-from collections.abc import Callable
-from functools import lru_cache
-
-
-@lru_cache(1)
-def _magic() -> Callable[[Path], str | None]:
-    try:
-        import magic
-    except Exception as e:
-        # logger.exception(e)
-        defensive_msg: str | None = None
-        if isinstance(e, ModuleNotFoundError) and e.name == 'magic':
-            defensive_msg = "python-magic is not detected. It's recommended for better file type detection (pip3 install --user python-magic). See https://github.com/ahupp/python-magic#installation"
-        elif isinstance(e, ImportError):
-            emsg = getattr(e, 'msg', '')  # make mypy happy
-            if 'failed to find libmagic' in emsg:  # probably the actual library is missing?...
-                defensive_msg = "couldn't import magic. See https://github.com/ahupp/python-magic#installation"
-        if defensive_msg is not None:
-            warnings.warn(defensive_msg, stacklevel=2)
-            return lambda path: None  # stub  # noqa: ARG005
-        else:
-            raise e
-    else:
-        mm = magic.Magic(mime=True)
-        return lambda path: mm.from_file(str(path))
-
-
-def mime(path: Path) -> str | None:
-    # next, libmagic, it might access the file, so a bit slower
-    magic = _magic()
-    return magic(path)
-
-
+from collections.abc import Collection
 from typing import Any
 
 Json = Any
-
-
-from collections.abc import Collection
 
 
 def delkeys(j: Json, *, keys: str | Collection[str]) -> None:


### PR DESCRIPTION

ok, libmagic was overkill for this sort of thing, much easier just to check header directly for a single usecase