### PR TITLE
core.modules.sqlite: signitifant speedups for cleanup/processing

### DIFF
--- a/src/bleanser/core/modules/sqlite.py
+++ b/src/bleanser/core/modules/sqlite.py
@@ -93,6 +93,8 @@ def _checked_db(db: Path, *, check: Literal['integrity', 'quick'], allowed_blobs
            'quick' is O(N), and mostly achieves same result.
     """
     db = _checked_no_wal(db)
+    # NOTE: with immutable=1, SQLite can skip some checks; e.g. integrity_check can return ok even if a normal
+    # connection reports CHECK constraint violations. Here this is mostly a cheap readonly sanity check.
     with closing(sqlite3.connect(f'file:{db}?immutable=1', uri=True)) as conn, conn:
         # note: .execute only does statement at a time?
         # TODO what does schema_version do?

--- a/src/bleanser/core/modules/tests/sqlite.py
+++ b/src/bleanser/core/modules/tests/sqlite.py
@@ -128,6 +128,39 @@ def test_sqlite_simple(tmp_path: Path) -> None:
     ]  # fmt: skip
 
 
+def _make_long_dump_db(to: Path, *, ignored_value: int, payload_suffix: str = '') -> Path:
+    with sqlite3.connect(to) as conn:
+        conn.execute('CREATE TABLE payloads (id INTEGER, body TEXT)')
+        conn.execute('CREATE TABLE ignored (value INTEGER)')
+        conn.execute('INSERT INTO ignored VALUES (?)', (ignored_value,))
+        # Regression shape for uutils sort 0.8.0: a few long lines made only of "a" are enough for `sort --unique --merge` to split SQL dump lines.
+        body = 'a' * 32_000 + payload_suffix
+        for i in range(3):
+            conn.execute('INSERT INTO payloads VALUES (?, ?)', (i, body))
+
+    return to
+
+
+def test_sqlite_long_dump_lines_end_to_end(tmp_path: Path) -> None:
+    class TestNormaliser(SqliteNormaliser):
+        def cleanup(self, c: sqlite3.Connection) -> None:
+            c.execute('DROP TABLE ignored')
+
+    db0 = _make_long_dump_db(tmp_path / '0.db', ignored_value=0)
+    db1 = _make_long_dump_db(tmp_path / '1.db', ignored_value=1)
+    db2 = _make_long_dump_db(tmp_path / '2.db', ignored_value=2)
+    db3 = _make_long_dump_db(tmp_path / '3.db', ignored_value=3, payload_suffix='b')
+
+    instructions = list(compute_instructions([db0, db1, db2, db3], Normaliser=TestNormaliser, threads=None))
+
+    assert [type(i) for i in instructions] == [
+        Keep,
+        Prune,
+        Keep,
+        Keep,
+    ]
+
+
 @pytest.mark.parametrize('multiway', [False, True])
 def test_sqlite_many(*, tmp_path: Path, multiway: bool) -> None:
     class TestNormaliser(SqliteNormaliser):

--- a/src/bleanser/core/processor.py
+++ b/src/bleanser/core/processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 import shutil
 import subprocess
 import sys
@@ -10,7 +11,6 @@ from concurrent.futures import Future, ProcessPoolExecutor
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from functools import cache
 from pathlib import Path
-from subprocess import check_call
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 from time import time
 from typing import (
@@ -40,6 +40,12 @@ from .common import (
     logger,
 )
 from .ext.dummy_executor import DummyExecutor
+
+
+def run_sort(*args: str | Path) -> None:
+    # Use bytewise collation for internal canonicalisation sorts; locale-aware sort can be much slower and may vary across environments, and bleanser compares exact dump lines rather than human-collated text.
+    env = {**os.environ, 'LC_ALL': 'C'}
+    subprocess.run(['sort', *(str(a) for a in args)], env=env, check=True)
 
 
 @contextmanager
@@ -81,7 +87,7 @@ def unique_file_in_tempdir(*, input_filepath: Path, dir: Path, suffix: str | Non
 # meh... see Fileset._union
 # this gives it a bit of a speedup when comparing
 def sort_file(filepath: str | Path) -> None:
-    check_call(['sort', '-o', str(filepath), str(filepath)])
+    run_sort('-o', filepath, filepath)
 
 
 Input = Path
@@ -361,20 +367,10 @@ class FileSet(AbstractContextManager):
         # allow it not to have merged file if set is empty
         tomerge = ([] if len(self.items) == 0 else [self.merged]) + extra
 
-        # hmm sadly sort command doesn't detect it itself?
-        # todo make less hacky... ideally the callee would maintain the sorted files
-        is_sorted = []
-        for p in tomerge:  # todo no need to check self.merged?
-            res = subprocess.run(['sort', '--check', p], check=False)
-            if res.returncode not in (0, 1):
-                res.check_returncode()
-            is_sorted.append(res.returncode == 0)
-        mflag = []
-        if all(is_sorted):
-            mflag = ['--merge']
-
-        # sort also has --parallel option... but pretty pointless, in most cases we'll be merging two files?
-        subprocess.check_call(['sort', '--unique', *mflag, *tomerge, '-o', self.merged])
+        # If every input is already sorted, sort --unique --merge can be a nice optimization because merge is linear and avoids re-sorting all lines from scratch.
+        # In practice it also needs a sort --check pass, and with LC_ALL=C the full sort --unique path is already cheap for current sqlite dumps: about 0.10s for one ~70MB dump and about 0.16-0.20s for two ~70MB dumps on observed Firefox history data.
+        # TODO: re-evaluate --merge if useful; uutils sort 0.8.0 can corrupt long lines in --merge mode.
+        run_sort('--unique', *tomerge, '-o', self.merged)
 
         self.items.extend(extra)
 


### PR DESCRIPTION
Especially noticeable on big databases like firefox.

Thanks to LC_ALL=C,

- for `sort` after sqlite dump: speeds up sorting 25-30x
- fileset operatoins are also much faster now, ~30-70x depending on case

Also there was an issue with new rust coreutils sort --merge flag implementation. We've moved away from --merge flag since sort is now super fast, but added a regression test.